### PR TITLE
docs: add instructions for accessing WordPress locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,27 @@ To get started with Angular, you can use the [Angular CLI](https://cli.angular.i
 ```shell
 $ ng new
 ```
+
+## Accessing the WordPress site locally
+
+This example project only contains the Angular front end; it does not bundle a
+WordPress installation. If you want to work against a WordPress instance while
+developing locally you will need to run WordPress separately and then point the
+Angular app to that instance's REST API.
+
+1. Spin up WordPress on your machine using your preferred method. Common
+   options include [Local WP](https://localwp.com/), the official
+   [`wp-env`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/)
+   Docker setup, or a custom Docker Compose stack. Make sure the site is
+   reachable from the browser (for example at `http://localhost:8888`).
+2. Update the Angular app to call your WordPress REST API endpoint. You can add
+   any necessary URLs to the environment configuration (for example in
+   `src/environments/environment.ts`) and use that value inside your services
+   when making HTTP requests.
+3. Start the Angular development server with `npm install` followed by
+   `npm run start`, then open `http://localhost:4200`. The front end can now
+   interact with the WordPress site you have running locally.
+
+Because WordPress runs independently from this Angular example, remember to
+keep both the WordPress server and the Angular dev server running whenever you
+need to test the integration.


### PR DESCRIPTION
## Summary
- document that the repository only contains the Angular front end
- add guidance for running a local WordPress instance and wiring the Angular app to it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e433c9f9408328bb6df284ad24582f